### PR TITLE
Ompt state wait barrier implicit parallel

### DIFF
--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -1726,7 +1726,10 @@ void __kmp_join_barrier(int gtid) {
     if (!KMP_MASTER_TID(ds_tid))
       this_thr->th.ompt_thread_info.task_data = *OMPT_CUR_TASK_DATA(this_thr);
 #endif
-    this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+    // vi3-ompt_state_wait_barrier_implicit_parallel:
+    // old
+    // this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+     this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit_parallel;
   }
 #endif
 
@@ -1983,8 +1986,12 @@ void __kmp_fork_barrier(int gtid, int tid) {
   }
 
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = (team)
                                  ? OMPT_CUR_TASK_DATA(this_thr)

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -7300,8 +7300,12 @@ void __kmp_internal_join(ident_t *id, int gtid, kmp_team_t *team) {
 
   __kmp_join_barrier(gtid); /* wait for everyone */
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = OMPT_CUR_TASK_DATA(this_thr);
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;

--- a/runtime/src/kmp_wait_release.h
+++ b/runtime/src/kmp_wait_release.h
@@ -123,7 +123,10 @@ static void __ompt_implicit_task_end(kmp_info_t *this_thr,
                                      ompt_state_t ompt_state,
                                      ompt_data_t *tId) {
   int ds_tid = this_thr->th.th_info.ds.ds_tid;
-  if (ompt_state == ompt_state_wait_barrier_implicit) {
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_state == ompt_state_wait_barrier_implicit) {
+  if (ompt_state == ompt_state_wait_barrier_implicit_parallel) {
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;
 #if OMPT_OPTIONAL
     void *codeptr = NULL;
@@ -267,7 +270,10 @@ final_spin=FALSE)
   ompt_data_t *tId;
   if (ompt_enabled.enabled) {
     ompt_entry_state = this_thr->th.ompt_thread_info.state;
-    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    // vi3-ompt_state_wait_barrier_implicit_parallel
+    // old
+    // if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit_parallel ||
         KMP_MASTER_TID(this_thr->th.th_info.ds.ds_tid)) {
       ompt_lw_taskteam_t *team =
           this_thr->th.th_team->t.ompt_serialized_team_info;

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -430,9 +430,10 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
         *thread_num = __kmp_get_tid();
       else if (prev_lwt)
         *thread_num = 0;
-      else
+      else if (prev_team){
         *thread_num = prev_team->t.t_master_tid;
-      //        *thread_num = team->t.t_master_tid;
+        //        *thread_num = team->t.t_master_tid;
+      }
     }
     return info ? 2 : 0;
   }


### PR DESCRIPTION
1. When a thread enters the last implicit barrier of a parallel region, its state should be set to: ompt_state_wait_barrier_implicit_parallel according to [OpenMP TR 9](https://www.openmp.org/wp-content/uploads/openmp-TR9.pdf).

2. Inside __ompt_get_task_info_internal function, check if prev_team exitst and then try to get information about master_tid.