### PR TITLE
ompt_get_task_info - bug fix

### DIFF
--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -1726,7 +1726,10 @@ void __kmp_join_barrier(int gtid) {
     if (!KMP_MASTER_TID(ds_tid))
       this_thr->th.ompt_thread_info.task_data = *OMPT_CUR_TASK_DATA(this_thr);
 #endif
-    this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+    // vi3-ompt_state_wait_barrier_implicit_parallel:
+    // old
+    // this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+     this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit_parallel;
   }
 #endif
 
@@ -1983,8 +1986,12 @@ void __kmp_fork_barrier(int gtid, int tid) {
   }
 
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = (team)
                                  ? OMPT_CUR_TASK_DATA(this_thr)

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -7300,8 +7300,12 @@ void __kmp_internal_join(ident_t *id, int gtid, kmp_team_t *team) {
 
   __kmp_join_barrier(gtid); /* wait for everyone */
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = OMPT_CUR_TASK_DATA(this_thr);
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;

--- a/runtime/src/kmp_tasking.cpp
+++ b/runtime/src/kmp_tasking.cpp
@@ -1831,6 +1831,8 @@ template <bool ompt>
 static kmp_int32 __kmpc_omp_taskwait_template(ident_t *loc_ref, kmp_int32 gtid,
                                               void *frame_address,
                                               void *return_address) {
+  // TODO: consider removing the return_address parameter
+  return_address = NULL;
   kmp_taskdata_t *taskdata;
   kmp_info_t *thread;
   int thread_finished = FALSE;
@@ -1853,12 +1855,18 @@ static kmp_int32 __kmpc_omp_taskwait_template(ident_t *loc_ref, kmp_int32 gtid,
       taskdata->ompt_task_info.frame.enter_frame.ptr = frame_address;
 
       if (ompt_enabled.ompt_callback_sync_region) {
+        if (!return_address)
+          return_address = OMPT_LOAD_RETURN_ADDRESS(gtid);
+
         ompt_callbacks.ompt_callback(ompt_callback_sync_region)(
             ompt_sync_region_taskwait, ompt_scope_begin, my_parallel_data,
             my_task_data, return_address);
       }
 
       if (ompt_enabled.ompt_callback_sync_region_wait) {
+        if (!return_address)
+          return_address = OMPT_LOAD_RETURN_ADDRESS(gtid);
+
         ompt_callbacks.ompt_callback(ompt_callback_sync_region_wait)(
             ompt_sync_region_taskwait, ompt_scope_begin, my_parallel_data,
             my_task_data, return_address);
@@ -1948,7 +1956,7 @@ kmp_int32 __kmpc_omp_taskwait(ident_t *loc_ref, kmp_int32 gtid) {
   if (UNLIKELY(ompt_enabled.enabled)) {
     OMPT_STORE_RETURN_ADDRESS(gtid);
     return __kmpc_omp_taskwait_ompt(loc_ref, gtid, OMPT_GET_FRAME_ADDRESS(0),
-                                    OMPT_LOAD_RETURN_ADDRESS(gtid));
+                                    NULL);
   }
 #endif
   return __kmpc_omp_taskwait_template<false>(loc_ref, gtid, NULL, NULL);

--- a/runtime/src/kmp_wait_release.h
+++ b/runtime/src/kmp_wait_release.h
@@ -123,7 +123,10 @@ static void __ompt_implicit_task_end(kmp_info_t *this_thr,
                                      ompt_state_t ompt_state,
                                      ompt_data_t *tId) {
   int ds_tid = this_thr->th.th_info.ds.ds_tid;
-  if (ompt_state == ompt_state_wait_barrier_implicit) {
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_state == ompt_state_wait_barrier_implicit) {
+  if (ompt_state == ompt_state_wait_barrier_implicit_parallel) {
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;
 #if OMPT_OPTIONAL
     void *codeptr = NULL;
@@ -267,7 +270,10 @@ final_spin=FALSE)
   ompt_data_t *tId;
   if (ompt_enabled.enabled) {
     ompt_entry_state = this_thr->th.ompt_thread_info.state;
-    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    // vi3-ompt_state_wait_barrier_implicit_parallel
+    // old
+    // if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit_parallel ||
         KMP_MASTER_TID(this_thr->th.th_info.ds.ds_tid)) {
       ompt_lw_taskteam_t *team =
           this_thr->th.th_team->t.ompt_serialized_team_info;

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -476,8 +476,21 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
       }
     }
     if (thread_num) {
-      if (level == 0)
+      if (level == 0) {
         *thread_num = __kmp_get_tid();
+#if 1
+        if (team->t.t_threads[0] == thr) {
+          // FIXME: If this function is called by the master thread of
+          //  the innermost region inside ompt_callback_implicit_task
+          //  (scope=end), this function may return thead_num different
+          //  then zero, which should be wrong.
+          //  This check should prevent this.
+          // thr is the master of the team
+          *thread_num = 0;
+          assert(*thread_num == 0);
+        }
+#endif
+      }
       else if (prev_lwt)
         *thread_num = 0;
       else if (prev_team){

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -476,6 +476,17 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
       }
     }
     if (thread_num) {
+      // FIXME vi3: This is wrong. However, hpcrun only cares about whether
+      //  thread is master of the region or not.
+      if (team) {
+        if (thr == team->t.t_threads[0]) {
+          *thread_num = 0;
+        } else {
+          *thread_num = -1;
+        }
+      }
+
+#if 0
       if (level == 0) {
         *thread_num = __kmp_get_tid();
 #if 1
@@ -541,6 +552,8 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
         //   satisfies standard)
         *thread_num = -1;
       }
+
+#endif
     }
     return info ? 2 : 0;
   }

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -430,9 +430,10 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
         *thread_num = __kmp_get_tid();
       else if (prev_lwt)
         *thread_num = 0;
-      else
+      else if (prev_team){
         *thread_num = prev_team->t.t_master_tid;
-      //        *thread_num = team->t.t_master_tid;
+        //        *thread_num = team->t.t_master_tid;
+      }
     }
     return info ? 2 : 0;
   }


### PR DESCRIPTION
According to standard specification, parallel_data should belongs to the region that contains task at specified ancestor level.

However, this is not always true in the current implementation of the ompt_get_task_info entry point.
The following scenario should explain when this can happen: 
- Assume that a thread is part of the region at depth 0 (reg0) and that it's executing the corresponding implicit task.
- Currently active team of the thread is the team of reg0, and the currently active task is the implicit task of reg0.
- Thread encounters at parallel construct, so it's going to form a new team of the nested region (reg1).
- After that, thread sets that its currently active team is the reg1's team.
- Note that still active task is the reg0's implicit task.
 - If someone calls ompt_get_task_info(0) at this moment, the function should return currently active task (reg0's implicit task) and the parallel_data that belongs to the region in which the mentioned task has been executed. (reg0's parallel_data).
- Unfortunately, the current implementation will return the parallel_data that belongs to the currently active team (reg1's team)

In order to prevent this, check if the team of the currently active task matches the team of the currently active region. If this is not true, then the previously described scenario occurred, so try to access to the parent region team and use its parallel_data word.

Also, standard isn't clear about the case when the worker thread of the innermost parallel region calls this function with ancestor_level 1 (or any value greater than 0). Since the worker of the innermost parallel region doesn't belong to the outer parallel region, then the question is what should be the return value of thread_num argument? The old implementation would find the master thread of the innermost region and use thread_num of this thread inside outer region. This obiuosly isn't right. The proposal is to use some invalid value, as indication to the tool that this thread is not the part of the region at ancestor_level 1 (or greater).

It should be checked whether the ompt_get_task_info handles properly the case when the task (implicit or explicit) doesn't exists on the specified ancestor_level (e.g there's 3 nested implicit tasks, and thread calls the function with ancestor_level 10). 