### PR TITLE
Sample delivered in the middle of new region/task initialization process.

### DIFF
--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -1726,7 +1726,10 @@ void __kmp_join_barrier(int gtid) {
     if (!KMP_MASTER_TID(ds_tid))
       this_thr->th.ompt_thread_info.task_data = *OMPT_CUR_TASK_DATA(this_thr);
 #endif
-    this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+    // vi3-ompt_state_wait_barrier_implicit_parallel:
+    // old
+    // this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+     this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit_parallel;
   }
 #endif
 
@@ -1983,8 +1986,12 @@ void __kmp_fork_barrier(int gtid, int tid) {
   }
 
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = (team)
                                  ? OMPT_CUR_TASK_DATA(this_thr)

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -7300,8 +7300,12 @@ void __kmp_internal_join(ident_t *id, int gtid, kmp_team_t *team) {
 
   __kmp_join_barrier(gtid); /* wait for everyone */
 #if OMPT_SUPPORT
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_enabled.enabled &&
+  //     this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
   if (ompt_enabled.enabled &&
-      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+      this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit_parallel) {
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
     ompt_data_t *task_data = OMPT_CUR_TASK_DATA(this_thr);
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;

--- a/runtime/src/kmp_wait_release.h
+++ b/runtime/src/kmp_wait_release.h
@@ -123,7 +123,10 @@ static void __ompt_implicit_task_end(kmp_info_t *this_thr,
                                      ompt_state_t ompt_state,
                                      ompt_data_t *tId) {
   int ds_tid = this_thr->th.th_info.ds.ds_tid;
-  if (ompt_state == ompt_state_wait_barrier_implicit) {
+  // vi3-ompt_state_wait_barrier_implicit_parallel
+  // old
+  // if (ompt_state == ompt_state_wait_barrier_implicit) {
+  if (ompt_state == ompt_state_wait_barrier_implicit_parallel) {
     this_thr->th.ompt_thread_info.state = ompt_state_overhead;
 #if OMPT_OPTIONAL
     void *codeptr = NULL;
@@ -267,7 +270,10 @@ final_spin=FALSE)
   ompt_data_t *tId;
   if (ompt_enabled.enabled) {
     ompt_entry_state = this_thr->th.ompt_thread_info.state;
-    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    // vi3-ompt_state_wait_barrier_implicit_parallel
+    // old
+    // if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit ||
+    if (!final_spin || ompt_entry_state != ompt_state_wait_barrier_implicit_parallel ||
         KMP_MASTER_TID(this_thr->th.th_info.ds.ds_tid)) {
       ompt_lw_taskteam_t *team =
           this_thr->th.th_team->t.ompt_serialized_team_info;

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -476,8 +476,21 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
       }
     }
     if (thread_num) {
-      if (level == 0)
+      if (level == 0) {
         *thread_num = __kmp_get_tid();
+#if 1
+        if (team->t.t_threads[0] == thr) {
+          // FIXME: If this function is called by the master thread of
+          //  the innermost region inside ompt_callback_implicit_task
+          //  (scope=end), this function may return thead_num different
+          //  then zero, which should be wrong.
+          //  This check should prevent this.
+          // thr is the master of the team
+          *thread_num = 0;
+          assert(*thread_num == 0);
+        }
+#endif
+      }
       else if (prev_lwt)
         *thread_num = 0;
       else if (prev_team){

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -430,9 +430,10 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
         *thread_num = __kmp_get_tid();
       else if (prev_lwt)
         *thread_num = 0;
-      else
+      else if (prev_team){
         *thread_num = prev_team->t.t_master_tid;
-      //        *thread_num = team->t.t_master_tid;
+        //        *thread_num = team->t.t_master_tid;
+      }
     }
     return info ? 2 : 0;
   }


### PR DESCRIPTION
The following commits should emphasize the problem of delivering the sample in the middle of the region/task initialization process. 

Since, this process is not done atomically, it is possible that the tool receive the sample in the middle of it (process) and calls the ompt_get_task_info function in order to get information about active tasks/regions. 
The proposal is to always initialize the task/region's descriptor before setting it to thread's descriptor as currently valid. Since the initialization process is scattered across multiple functions and even multiple threads, it is possible that these changes won't handle all edge cases. However, they should point out to the problems that should be consider in future.

The best way to handle this problem is to introduce some variable that should show whether thread is initializing the region/task. If so, the ompt_get_task_info could return the value 1, which should indicate that there'a a task/region at this level, but the information about it are incomplete (this should satisfies the OMPT 5.0 standard specification). However, this approach would require memoizing some information about the old task/region during the process of setting the new one, so it may introduce additional memory footprint.